### PR TITLE
Support ubuntu gdm3

### DIFF
--- a/src/snappyzones/service.py
+++ b/src/snappyzones/service.py
@@ -2,6 +2,7 @@ from Xlib import X, XK
 from Xlib.ext import record
 from Xlib.display import Display
 from Xlib.protocol import rq
+from Xlib.xobject.drawable import Window
 
 from .snap import snap_window, shift_window
 from .zoning import ZoneProfile
@@ -9,7 +10,9 @@ from .conf.settings import SETTINGS
 
 
 class Service:
-    def __init__(self) -> None:
+    def __init__(self, window_manager:str = None) -> None:
+        
+        self.window_manager = window_manager
         self.active_keys = {
             XK.string_to_keysym(key): False for key in SETTINGS.keybindings
         }
@@ -66,11 +69,10 @@ class Service:
             if all(self.active_keys.values()):
                 self.coordinates.add(event.root_x, event.root_y)
                 if (event.type, event.detail) == (X.ButtonRelease, X.Button1):
-                    snap_window(self, event.root_x, event.root_y)
+                    snap_window(self, event.root_x, event.root_y, window_manager=self.window_manager)
                 elif event.type == X.KeyPress:
                     keysym = self.display.keycode_to_keysym(event.detail, 0)
-                    shift_window(self, keysym)
-
+                    shift_window(self, keysym, window_manager=self.window_manager)
             else:
                 self.coordinates.clear()
 

--- a/src/snappyzones/snap.py
+++ b/src/snappyzones/snap.py
@@ -1,7 +1,16 @@
+import logging
 from Xlib import X, XK
 from Xlib.error import BadDrawable, XError
 from Xlib.display import Display
+from Xlib.xobject.drawable import Window
 
+logger = logging.getLogger(__name__)
+
+# the default gdm3 offsets due to shadows, borders etc
+GEOMETRY_DELTAS_SNAP_GDM3 = 26,23,-57,-97
+# The offset to apply to the window when saving because the visual part of the
+# display box is not exactly the same as it's xlib coordinates
+GEOMETRY_DELTAS_SAVE_GDM3 = 10,-19,-20,-55
 
 def active_window(display, window_id=None):
     if not window_id:
@@ -18,13 +27,19 @@ def active_window(display, window_id=None):
         return None
 
 
-def geometry_deltas(window):
+def geometry_deltas(window:Window, window_manager:str = None):
     """The window of an app usually sits within an Xorg parent frame, and we
     want to fit that parent frame to the zone and not the inner window (so
     decorations like borders are properly handled). I can't seem to get that
     window to update directly, so we'll update the child window using the
     difference b/t the parent and child so to fit the final result
     correctly."""
+    if window_manager == "gdm3":
+        # In the case of gdm3, the above strategy doesnt seem to work.
+        # When searching for parent frames, you quickly get to the root frame
+        # without any obvious way of figuring out how big the shadow elements etc
+        # are. So as a workaround, we hardcode them here.
+        return GEOMETRY_DELTAS_SNAP_GDM3 
     wg = window.get_geometry()
     dx, dy, dw, dh = 0, 0, 0, 0
     parent = window.query_tree().parent
@@ -36,21 +51,30 @@ def geometry_deltas(window):
     return dx, dy, dw, dh
 
 
-def shift_window(self, keysym, stretch=False):
+def geometry_deltas_save(window_manager:str = None):
+    if window_manager == "gdm3":
+        return GEOMETRY_DELTAS_SAVE_GDM3
+    else:
+        return 0,0,0,0
+
+
+def shift_window(self, keysym, stretch=False, window_manager=None):
     try:
         display = Display()
         zone_profile = self.zp
         window = active_window(display)
-        wg = window.get_geometry()
         dx, dy, dw, dh = geometry_deltas(window)
-        pg = window.query_tree().parent.query_tree().parent.get_geometry()
+        if window_manager == "gdm3":
+            pg = window.get_geometry()
+        else:
+            pg = window.query_tree().parent.query_tree().parent.get_geometry()
         zone = zone_profile.find_zone(pg.x + pg.width / 2, pg.y + pg.height / 2, keysym)
         if window and zone:
             window.configure(
-                x=zone.x,
-                y=zone.y,
-                width=zone.width - dx,
-                height=zone.height - dy,
+                x=zone.x - dx,
+                y=zone.y - dy,
+                width=zone.width - dw,
+                height=zone.height - dh,
                 stack_mode=X.Above,
             )
             display.sync()
@@ -58,19 +82,19 @@ def shift_window(self, keysym, stretch=False):
         pass
 
 
-def snap_window(self, x, y):
+def snap_window(self, x, y, window_manager=None):
     try:
         display = Display()
         zone_profile = self.zp
         window = active_window(display)
-        dx, dy, dw, dh = geometry_deltas(window)
+        dx, dy, dw, dh = geometry_deltas(window, window_manager=window_manager)
         zone = zone_profile.find_zones(self, x, y)
         if window and zone:
             window.configure(
-                x=zone.x,
-                y=zone.y,
-                width=zone.width - dx,
-                height=zone.height - dy,
+                x=zone.x - dx,
+                y=zone.y - dy,
+                width=zone.width - dw,
+                height=zone.height - dh,
                 stack_mode=X.Above,
             )
             display.sync()


### PR DESCRIPTION
This is the first of a few pull requests I've got lined up.

The existing code does not seem to work with ubuntu Ubuntu 22.04.2 LTS, 

I am no X11/xlib expert, but it looks like this is because the window heirarchy is different in gdm3 compared with what the author was using to develop snappyzones.

For example when traversing the tree to the parent window, in gdm3 you quickly end up at the root window, rather than a 'frame window' containing the elements of interest.

This resolves the issue (or at least gets it closer to a working solution) by detecting the window manager on startup, then triggering different logic. Since I don't have the ability to test the original window manager, this seemed like the safest option.

There are some hardcoded constants in the new code, and I expect these relate to the size of the shadow settings etc in ubuntu. These are based on the default settings, and are just a start point. Perhaps a future PR can calculate precise values somehow by an x11 based measurement or maybe reading the user's config.

This is just a start.

Fixes #4

P.S. I also added some basic logging which will come in useful later.

The follow on PRs that I've got working locally add some graphical enhancements, the main one being a preview of where the window will expand to before the drag is released.